### PR TITLE
Add aria-hidden to resume skills icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 					</div>
 					<ul>
 						<li><a href="/portfolio/" class="nav-link">Portfolio</a></li>
-						<li><a href="/resume/" class="nav-link">Resume</a></li>
+						<li><a href="/resume/" class="nav-link">Résumé</a></li>
 						<li><a href="#contact" class="nav-link">Contact</a></li>
 					</ul>
 				</nav>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -28,7 +28,7 @@
 					</div>
 					<ul>
 						<li><p>Portfolio</p></li>
-						<li><a href="/resume/" class="nav-link">Resume</a></li>
+						<li><a href="/resume/" class="nav-link">Résumé</a></li>
 						<li><a href="#contact" class="nav-link">Contact</a></li>
 					</ul>
 				</nav>

--- a/portfolio/performance-plastics/index.html
+++ b/portfolio/performance-plastics/index.html
@@ -33,7 +33,7 @@
 					</div>
 					<ul>
 						<li><a href="../" class="nav-link">Portfolio</a></li>
-						<li><a href="../../resume/" class="nav-link">Resume</a></li>
+						<li><a href="../../resume/" class="nav-link">Résumé</a></li>
 						<li><a href="#contact" class="nav-link">Contact</a></li>
 					</ul>
 				</nav>

--- a/portfolio/speed-game/index.html
+++ b/portfolio/speed-game/index.html
@@ -33,7 +33,7 @@
 					</div>
 					<ul>
 						<li><a href="../" class="nav-link">Portfolio</a></li>
-						<li><a href="../../resume/" class="nav-link">Resume</a></li>
+						<li><a href="../../resume/" class="nav-link">Résumé</a></li>
 						<li><a href="#contact" class="nav-link">Contact</a></li>
 					</ul>
 				</nav>

--- a/portfolio/thecocktailapp/index.html
+++ b/portfolio/thecocktailapp/index.html
@@ -33,7 +33,7 @@
 					</div>
 					<ul>
 						<li><a href="../" class="nav-link">Portfolio</a></li>
-						<li><a href="../../resume/" class="nav-link">Resume</a></li>
+						<li><a href="../../resume/" class="nav-link">Résumé</a></li>
 						<li><a href="#contact" class="nav-link">Contact</a></li>
 					</ul>
 				</nav>

--- a/resume/index.html
+++ b/resume/index.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="../style.css" />
 		<link rel="stylesheet" href="resume-style.css" />
 		<link rel="shortcut icon" href="../../img/logo.png" type="image/x-icon" />
-		<title>Resume - Laurie Lim Sam</title>
+		<title>Résumé - Laurie Lim Sam</title>
 	</head>
 	<body>
 		<div class="page-wrapper">
@@ -30,7 +30,7 @@
 					<ul>
 						<li><a href="/portfolio" class="nav-link">Portfolio</a></li>
 						<li>
-							<p><span class="visually-hidden">Current Page: </span>Resume</p>
+							<p><span class="visually-hidden">Current Page: </span>Résumé</p>
 						</li>
 						<li><a href="#contact" class="nav-link">Contact</a></li>
 					</ul>
@@ -44,7 +44,7 @@
 			</header>
 			<main>
 				<section class="resume">
-					<h1>Resume</h1>
+					<h1>Résumé</h1>
 					<a
 						href="https://docs.google.com/document/d/1FDVH_4BRTEWnmCwYpzUDtB1_q0nOVdNdJMHP-rrP4Jc/edit?usp=sharing"
 						>Download a copy from Google Docs</a

--- a/resume/index.html
+++ b/resume/index.html
@@ -280,6 +280,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>HTML5 icon</title>
 										<path
@@ -294,6 +295,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>CSS3 icon</title>
 										<path
@@ -308,6 +310,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>Sass icon</title>
 										<path
@@ -322,6 +325,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>JavaScript icon</title>
 										<path
@@ -336,6 +340,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>React icon</title>
 										<path
@@ -350,6 +355,7 @@
 										xmlns="http://www.w3.org/2000/svg"
 										viewBox="0 0 24 24"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>Redux icon</title>
 										<path
@@ -369,6 +375,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>PHP icon</title>
 										<path
@@ -383,6 +390,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>Symfony icon</title>
 										<path
@@ -397,6 +405,7 @@
 										xmlns="http://www.w3.org/2000/svg"
 										viewBox="0 0 24 24"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>MySQL icon</title>
 										<path
@@ -411,6 +420,7 @@
 										xmlns="http://www.w3.org/2000/svg"
 										viewBox="0 0 24 24"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>MariaDB icon</title>
 										<path
@@ -425,6 +435,7 @@
 										xmlns="http://www.w3.org/2000/svg"
 										viewBox="0 0 24 24"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>Drupal icon</title>
 										<path
@@ -439,6 +450,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>WordPress icon</title>
 										<path
@@ -458,6 +470,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>Figma icon</title>
 										<path
@@ -472,6 +485,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>Adobe Illustrator icon</title>
 										<path
@@ -486,6 +500,7 @@
 										viewBox="0 0 24 24"
 										xmlns="http://www.w3.org/2000/svg"
 										class="svg-icon"
+										aria-hidden="true"
 									>
 										<title>Adobe Photoshop icon</title>
 										<path


### PR DESCRIPTION
Changed "Resume" to "Résumé" for VoiceOver to read it out correctly and added aria-hidden to the skills icon as they are purely decorative.